### PR TITLE
Parcelize entity

### DIFF
--- a/app/src/androidTest/java/bottomnav/thesevchefs/com/cooktasty/ParcelableEntityTest.java
+++ b/app/src/androidTest/java/bottomnav/thesevchefs/com/cooktasty/ParcelableEntityTest.java
@@ -1,0 +1,120 @@
+package bottomnav.thesevchefs.com.cooktasty;
+
+import android.os.Parcel;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.sql.Time;
+import java.util.Date;
+
+import bottomnav.thesevchefs.com.cooktasty.entity.Recipe;
+import bottomnav.thesevchefs.com.cooktasty.entity.RecipeIngredient;
+import bottomnav.thesevchefs.com.cooktasty.entity.RecipeInstruction;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+@RunWith(AndroidJUnit4.class)
+public class ParcelableEntityTest {
+
+    @Test
+    public void test_recipe_instruction_is_parcelable() {
+        int stepNum = 1;
+        String instructionText = "test instruction";
+        Time time_required = new Time(1000);
+        String imageUrl = "image/test.jpg";
+        RecipeInstruction ri = new RecipeInstruction(stepNum, instructionText, time_required, imageUrl);
+
+        Parcel riParcel = Parcel.obtain();
+        ri.writeToParcel(riParcel, ri.describeContents());
+        riParcel.setDataPosition(0);
+
+        RecipeInstruction createdFromParcel = RecipeInstruction.CREATOR.createFromParcel(riParcel);
+
+        assertThat(createdFromParcel.step_num, is(stepNum));
+        assertThat(createdFromParcel.instruction, is(instructionText));
+        assertThat(createdFromParcel.time_required, is(time_required));
+        assertThat(createdFromParcel.image_url, is(imageUrl));
+    }
+
+    @Test
+    public void test_recipe_ingredient_is_parcelable() {
+
+        long ingredientId = 1;
+        String name = "onion";
+        String imageUrl = "image/test.jpg";
+        String servingSize = "10 gram";
+        RecipeIngredient ri = new RecipeIngredient(ingredientId, name, imageUrl, servingSize);
+
+        Parcel riParcel = Parcel.obtain();
+        ri.writeToParcel(riParcel, ri.describeContents());
+        riParcel.setDataPosition(0);
+
+        RecipeIngredient createdFromParcel = RecipeIngredient.CREATOR.createFromParcel(riParcel);
+
+        assertThat(createdFromParcel.serving_size, is(servingSize));
+        assertThat(createdFromParcel.ingredient.id, is(ingredientId));
+        assertThat(createdFromParcel.ingredient.name, is(name));
+        assertThat(createdFromParcel.ingredient.image_url, is(imageUrl));
+    }
+
+    @Test
+    public void test_recipe_is_parcelable() {
+
+        long repId = 1;
+        String repName = "recipe1";
+        String repDesc = "recipe desc test";
+        long repUploadUser = 1;
+        int repDifficultyLevel = 1;
+        Time repDuration = new Time(10);
+        Date repUploadDatetime = new Date(100);
+        String repImageUrl = "test/image.jpg";
+        Boolean repFavourited = true;
+
+        int instructionStepNum = 1;
+        String instructionText = "test instruction";
+        Time instructionTimeRequired = new Time(10);
+        String instructionImageUrl = "image/test.jpg";
+        RecipeInstruction[] repInstruction = {new RecipeInstruction(instructionStepNum, instructionText, instructionTimeRequired, instructionImageUrl)};
+
+        long ingredientId = 1;
+        String ingredientName = "onion";
+        String ingredientImageUrl = "image/test.jpg";
+        String ingredientServingSize = "10 gram";
+        RecipeIngredient[] repIngredients = {new RecipeIngredient(ingredientId, ingredientName, ingredientImageUrl, ingredientServingSize)};
+
+        Recipe recipe = new Recipe(repId, repName, repDesc, repUploadUser, repDifficultyLevel, repDuration, repUploadDatetime, repImageUrl, repFavourited, repIngredients, repInstruction);
+
+        Parcel recipeParcel = Parcel.obtain();
+        recipe.writeToParcel(recipeParcel, recipe.describeContents());
+        recipeParcel.setDataPosition(0);
+
+        Recipe createdFromParcel = Recipe.CREATOR.createFromParcel(recipeParcel);
+
+        assertThat(createdFromParcel.id, is(repId));
+        assertThat(createdFromParcel.name, is(repName));
+        assertThat(createdFromParcel.description, is(repDesc));
+        assertThat(createdFromParcel.upload_by_user, is(repUploadUser));
+        assertThat(createdFromParcel.difficulty_level, is(repDifficultyLevel));
+        assertThat(createdFromParcel.time_required, is(repDuration));
+        assertThat(createdFromParcel.upload_datetime, is(repUploadDatetime));
+        assertThat(createdFromParcel.image_url, is(repImageUrl));
+        assertThat(createdFromParcel.is_favourited, is(repFavourited));
+
+        assertThat(createdFromParcel.instructions[0].step_num, is(instructionStepNum));
+        assertThat(createdFromParcel.instructions[0].instruction, is(instructionText));
+        assertThat(createdFromParcel.instructions[0].time_required, is(instructionTimeRequired));
+        assertThat(createdFromParcel.instructions[0].image_url, is(instructionImageUrl));
+
+        assertThat(createdFromParcel.ingredients[0].ingredient.id, is(ingredientId));
+        assertThat(createdFromParcel.ingredients[0].ingredient.name, is(ingredientName));
+        assertThat(createdFromParcel.ingredients[0].ingredient.image_url, is(ingredientImageUrl));
+        assertThat(createdFromParcel.ingredients[0].serving_size, is(ingredientServingSize));
+
+    }
+
+
+}

--- a/app/src/main/java/bottomnav/thesevchefs/com/cooktasty/entity/ParcelableHelper.java
+++ b/app/src/main/java/bottomnav/thesevchefs/com/cooktasty/entity/ParcelableHelper.java
@@ -1,0 +1,43 @@
+package bottomnav.thesevchefs.com.cooktasty.entity;
+
+import android.os.Parcel;
+
+import java.sql.Time;
+import java.util.Date;
+
+/**
+ * Created by Admin on 1/11/2017.
+ */
+
+public class ParcelableHelper {
+
+    public static void writeBoolean(Parcel destination, Boolean value) {
+        if (destination != null) {
+            destination.writeInt(value ? 1 : 0);
+        }
+    }
+
+    public static Boolean readBoolean(Parcel in) {
+        if (in != null) {
+            return (in.readInt() == 1);
+        }
+        return false;
+    }
+
+    public static void writeDate(Parcel destination, Date dateObject) {
+        destination.writeLong(dateObject.getTime());
+    }
+
+    public static Date readDate(Parcel in) {
+        return new Date(in.readLong());
+    }
+
+    public static void writeTime(Parcel destination, Time timeObject) {
+        destination.writeLong(timeObject.getTime());
+    }
+
+    public static Time readTime(Parcel in) {
+        return new Time(in.readLong());
+    }
+
+}

--- a/app/src/main/java/bottomnav/thesevchefs/com/cooktasty/entity/Recipe.java
+++ b/app/src/main/java/bottomnav/thesevchefs/com/cooktasty/entity/Recipe.java
@@ -1,5 +1,8 @@
 package bottomnav.thesevchefs.com.cooktasty.entity;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.sql.Time;
 import java.util.Date;
 
@@ -7,7 +10,7 @@ import java.util.Date;
  * Created by Jun Jie on 31/10/2017.
  */
 
-public class Recipe {
+public class Recipe implements Parcelable {
 
     public long id;
     public String name;
@@ -17,8 +20,68 @@ public class Recipe {
     public Time time_required;
     public Date upload_datetime;
     public String image_url;
-    public RecipeIngredient[] ingredients;
     public Boolean is_favourited;
+    public RecipeIngredient[] ingredients;
     public RecipeInstruction[] instructions;
+
+    public Recipe(long id, String name, String description, long upload_by_user, int difficulty_level, Time time_required, Date upload_datetime, String image_url, Boolean is_favourited, RecipeIngredient[] ingredients, RecipeInstruction[] instructions) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.upload_by_user = upload_by_user;
+        this.difficulty_level = difficulty_level;
+        this.time_required = time_required;
+        this.upload_datetime = upload_datetime;
+        this.image_url = image_url;
+        this.is_favourited = is_favourited;
+        this.ingredients = ingredients;
+        this.instructions = instructions;
+    }
+
+    protected Recipe(Parcel in) {
+        id = in.readLong();
+        name = in.readString();
+        description = in.readString();
+        upload_by_user = in.readLong();
+        difficulty_level = in.readInt();
+        time_required = ParcelableHelper.readTime(in);
+        upload_datetime = ParcelableHelper.readDate(in);
+        image_url = in.readString();
+        is_favourited = ParcelableHelper.readBoolean(in);
+        ingredients = in.createTypedArray(RecipeIngredient.CREATOR);
+        instructions = in.createTypedArray(RecipeInstruction.CREATOR);
+    }
+
+    public static final Creator<Recipe> CREATOR = new Creator<Recipe>() {
+        @Override
+        public Recipe createFromParcel(Parcel in) {
+            return new Recipe(in);
+        }
+
+        @Override
+        public Recipe[] newArray(int size) {
+            return new Recipe[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeLong(id);
+        dest.writeString(name);
+        dest.writeString(description);
+        dest.writeLong(upload_by_user);
+        dest.writeInt(difficulty_level);
+        ParcelableHelper.writeTime(dest, time_required);
+        ParcelableHelper.writeDate(dest, upload_datetime);
+        dest.writeString(image_url);
+        ParcelableHelper.writeBoolean(dest, is_favourited);
+        dest.writeTypedArray(ingredients, 0);
+        dest.writeTypedArray(instructions, 0);
+    }
 
 }

--- a/app/src/main/java/bottomnav/thesevchefs/com/cooktasty/entity/RecipeIngredient.java
+++ b/app/src/main/java/bottomnav/thesevchefs/com/cooktasty/entity/RecipeIngredient.java
@@ -1,18 +1,91 @@
 package bottomnav.thesevchefs.com.cooktasty.entity;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 /**
  * Created by Jun Jie on 31/10/2017.
  */
 
-public class RecipeIngredient {
+public class RecipeIngredient implements Parcelable{
 
     public IngredientDetail ingredient;
     public String serving_size;
 
-    public class IngredientDetail {
+    public RecipeIngredient(long ingredientId, String ingredientName, String ingredientImageUrl, String serving_size) {
+        IngredientDetail ingredientDetail = new IngredientDetail(ingredientId, ingredientName, ingredientImageUrl);
+        this.ingredient = ingredientDetail;
+        this.serving_size = serving_size;
+    }
+
+    protected RecipeIngredient(Parcel in) {
+        ingredient = (IngredientDetail) in.readValue(IngredientDetail.class.getClassLoader());
+        serving_size = in.readString();
+    }
+
+    public static final Creator<RecipeIngredient> CREATOR = new Creator<RecipeIngredient>() {
+        @Override
+        public RecipeIngredient createFromParcel(Parcel in) {
+            return new RecipeIngredient(in);
+        }
+
+        @Override
+        public RecipeIngredient[] newArray(int size) {
+            return new RecipeIngredient[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeValue(ingredient);
+        dest.writeString(serving_size);
+    }
+
+    public static class IngredientDetail implements Parcelable {
         public long id;
         public String name;
         public String image_url;
+
+        public IngredientDetail(long id, String name, String image_url) {
+            this.id = id;
+            this.name = name;
+            this.image_url = image_url;
+        }
+
+        protected IngredientDetail(Parcel in) {
+            id = in.readLong();
+            name = in.readString();
+            image_url = in.readString();
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            dest.writeLong(id);
+            dest.writeString(name);
+            dest.writeString(image_url);
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        public final static Creator<IngredientDetail> CREATOR = new Creator<IngredientDetail>() {
+            @Override
+            public IngredientDetail createFromParcel(Parcel in) {
+                return new IngredientDetail(in);
+            }
+
+            @Override
+            public IngredientDetail[] newArray(int size) {
+                return new IngredientDetail[size];
+            }
+        };
     }
 
 }

--- a/app/src/main/java/bottomnav/thesevchefs/com/cooktasty/entity/RecipeInstruction.java
+++ b/app/src/main/java/bottomnav/thesevchefs/com/cooktasty/entity/RecipeInstruction.java
@@ -1,14 +1,57 @@
 package bottomnav.thesevchefs.com.cooktasty.entity;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.sql.Time;
 
 /**
  * Created by Jun Jie on 31/10/2017.
  */
 
-public class RecipeInstruction {
+public class RecipeInstruction implements Parcelable{
     public int step_num;
     public String instruction;
     public Time time_required;
     public String image_url;
+
+    public RecipeInstruction(int step_num, String instruction, Time time_required, String image_url) {
+        this.step_num = step_num;
+        this.instruction = instruction;
+        this.time_required = time_required;
+        this.image_url = image_url;
+    }
+
+    protected RecipeInstruction(Parcel in) {
+
+        step_num = in.readInt();
+        instruction = in.readString();
+        time_required = ParcelableHelper.readTime(in);
+        image_url = in.readString();
+    }
+
+    public static final Creator<RecipeInstruction> CREATOR = new Creator<RecipeInstruction>() {
+        @Override
+        public RecipeInstruction createFromParcel(Parcel in) {
+            return new RecipeInstruction(in);
+        }
+
+        @Override
+        public RecipeInstruction[] newArray(int size) {
+            return new RecipeInstruction[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(step_num);
+        dest.writeString(instruction);
+        ParcelableHelper.writeTime(dest, time_required);
+        dest.writeString(image_url);
+    }
 }


### PR DESCRIPTION
## Implement parcelable entities
We will be able to pass `recipe`, `instructions`, `ingredient` objects via `intent` to next activity using `parcels`.

#### 1. Put recipe entity into a parcel
```
Recipe recipe = new Recipe();
Intent intent = new Intent(this, NextActivity.class);
intent.putExtra(“recipe_data”, recipe);
startActivity(intent);
```
#### 2. Get recipe entity from intent
```
Recipe recipe = (Recipe) getIntent().getParcelableExtra("recipe_data");
```

refer to http://www.techjini.com/blog/passing-objects-via-intent-in-android/ for tutorial on parcelable